### PR TITLE
Fix CCI config to allow worker images to be pushed to PreProd ECR.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ aliases:
     command: |
       source $BASH_ENV
       docker tag ${AWS_ACCOUNT_DEV}.dkr.ecr.${AWS_REGION}.amazonaws.com/worker:${CIRCLE_TAG} ${AWS_ACCOUNT_PREPROD}.dkr.ecr.${AWS_REGION}.amazonaws.com/worker:${CIRCLE_TAG}
-      docker push ${AWS_ACCOUNT_PREPROD}.dkr.ecr.${AWS_REGION}.amazonaws.com/csv-worker:${CIRCLE_TAG}
+      docker push ${AWS_ACCOUNT_PREPROD}.dkr.ecr.${AWS_REGION}.amazonaws.com/worker:${CIRCLE_TAG}
   - &push_prod_ecr
     name: Push to prod ECR
     command: |


### PR DESCRIPTION
## Description

Fix CCI config to allow worker images to be pushed to PreProd ECR.

## Checklist

- [ ] All unit tests passing
- [ ] Code coverage suitable
- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] Commit messages are meaningful
- [ ] Target is green https://circleci.com/gh/departmentfortransport/street-manager-worker/tree/master
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge