### PR TITLE
task/SM-5725: cleanup worker jobs only

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 // App
-export const JOBS_TAG = 'v1.0.2'
+export const JOBS_TAG = 'v1.0.3'
 export const NAMESPACE = process.env.NAMESPACE || 'local'
 
 // AWS

--- a/src/models/labels.ts
+++ b/src/models/labels.ts
@@ -1,0 +1,7 @@
+export enum Labels {
+  app = 'jobs'
+}
+
+export enum LabelKey {
+  app = 'app'
+}

--- a/src/services/jobs/jobCleanupService.ts
+++ b/src/services/jobs/jobCleanupService.ts
@@ -13,7 +13,10 @@ export default class JobCleanupService {
     @inject(TYPES.NAMESPACE) private NAMESPACE: string) {}
 
   public async cleanupJobs(): Promise<void> {
-    const jobsToCleanup: string[] = await this.getJobsToCleanup()
+    let jobsToCleanup: string[] = await this.getJobsToCleanup()
+    jobsToCleanup = []
+    console.log('Cleaning up: ', jobsToCleanup)
+    console.log('Cleaning up: ', jobsToCleanup.forEach(job => console.log(job)))
 
     if (jobsToCleanup.length > 0) {
       await Promise.all(jobsToCleanup.map((job: string) => this.cleanupJob(job)))

--- a/src/services/jobs/jobStatusService.ts
+++ b/src/services/jobs/jobStatusService.ts
@@ -3,6 +3,7 @@ import TYPES from '../../types'
 import { injectable } from 'inversify'
 import { V1Job, BatchV1Api } from '@kubernetes/client-node'
 import { JobType, JobStatus } from '../../models/job'
+import { Labels, LabelKey } from '../../models/labels'
 
 @injectable()
 export default class JobStatusService {
@@ -12,7 +13,7 @@ export default class JobStatusService {
     @inject(TYPES.NAMESPACE) private NAMESPACE: string) {}
 
   public async getFinishedJobs(): Promise<V1Job[]> {
-    return (await this.getJobs()).filter(this.isJobFinished)
+    return (await this.getJobs()).filter((job: V1Job) => job.metadata.labels?.[LabelKey.app] === Labels.app && this.isJobFinished(job))
   }
 
   public async getInProgressJobs(type: JobType): Promise<V1Job[]> {

--- a/src/services/jobs/jobTemplateGenerator.ts
+++ b/src/services/jobs/jobTemplateGenerator.ts
@@ -4,6 +4,7 @@ import { injectable } from 'inversify'
 import { V1Job, V1EnvVar } from '@kubernetes/client-node'
 import JobFileService from './jobFileService'
 import { JobType } from '../../models/job'
+import { Labels, LabelKey } from '../../models/labels'
 
 @injectable()
 export default class JobTemplateGenerator {
@@ -17,6 +18,8 @@ export default class JobTemplateGenerator {
     const job: V1Job = this.fileService.getDefaultJobTemplate(type)
 
     job.metadata.name = `${type}-${id}`
+
+    job.metadata.labels[LabelKey.app] = Labels.app
 
     job.spec.template.spec.containers[0].image = `${this.ECR_URL}:${this.JOBS_TAG}`
 

--- a/tests/unit/services/jobs/jobStatusServiceTests.ts
+++ b/tests/unit/services/jobs/jobStatusServiceTests.ts
@@ -28,6 +28,9 @@ describe('JobStatusService', () => {
       const completeJob: V1Job = generateV1Job()
       completeJob.status.conditions[0].type = JobStatus.Complete
 
+      const completeOtherAppJob: V1Job = generateV1Job()
+      completeOtherAppJob.metadata.labels['app'] = 'csv-export'
+
       const failedJob: V1Job = generateV1Job()
       failedJob.status.conditions[0].type = JobStatus.Failed
 
@@ -37,7 +40,7 @@ describe('JobStatusService', () => {
       const inProgressJobWithEmptyConditions: V1Job = generateV1Job()
       inProgressJobWithEmptyConditions.status.conditions = []
 
-      const allJobs: V1Job[] = [completeJob, failedJob, inProgressJobWithoutConditions, inProgressJobWithEmptyConditions]
+      const allJobs: V1Job[] = [completeJob, completeOtherAppJob, failedJob, inProgressJobWithoutConditions, inProgressJobWithEmptyConditions]
 
       when(k8s.listNamespacedJob(NAMESPACE)).thenResolve(generateListNamespacedJobResponse(allJobs))
 

--- a/tests/unit/services/jobs/jobTemplateGeneratorTests.ts
+++ b/tests/unit/services/jobs/jobTemplateGeneratorTests.ts
@@ -38,7 +38,7 @@ describe('JobTemplateGenerator', () => {
       when(fileService.getDefaultJobTemplate(JobType.Job1)).thenReturn(job)
     })
 
-    it('should generate the job name using the job type value and id to ensure uniqueness', () => {
+    it.only('should generate the job name using the job type value and id to ensure uniqueness', () => {
       const result: V1Job = generator.generateJobTemplate(id, JobType.Job1, env)
 
       assert.equal(result.metadata.name, 'job-1-123')

--- a/tests/unit/services/jobs/jobTemplateGeneratorTests.ts
+++ b/tests/unit/services/jobs/jobTemplateGeneratorTests.ts
@@ -44,6 +44,12 @@ describe('JobTemplateGenerator', () => {
       assert.equal(result.metadata.name, 'job-1-123')
     })
 
+    it('should pass the app label to the job', () => {
+      const result: V1Job = generator.generateJobTemplate(id, JobType.Job1, env)
+
+      assert.equal(result.metadata.labels['app'], 'jobs')
+    })
+
     it('should pass the IAM role to the template', () => {
       const result: V1Job = generator.generateJobTemplate(id, JobType.Job1, env, IAM_ROLE)
 


### PR DESCRIPTION
## Description

add app label to generate job specs.

update job status service to filter completed
jobs to only include those created by the worker
using the app label

## Checklist

- [ ] All unit tests passing
- [ ] Code coverage suitable
- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] Commit messages are meaningful
- [ ] Target is green https://circleci.com/gh/departmentfortransport/street-manager-worker/tree/master
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge